### PR TITLE
Add support for "developer" role in Messages type

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -7,7 +7,7 @@ import { SSEStreamingApi, streamSSE } from "jsr:@hono/hono/streaming";
 
 import * as cache from "./../cache.ts";
 
-type Messages = { content: string; role: "user" | "assistant" | "system" }[];
+type Messages = { content: string; role: "user" | "assistant" | "system" | "developer" }[];
 
 type MessageData = {
   id: string;
@@ -134,7 +134,7 @@ function chat(app: Hono<BlankEnv, BlankSchema, "/">) {
     const model_name: ModelAlias = body.model;
     let messages: Messages = body.messages;
 
-    if (messages[0].role === "system") {
+    if (messages[0].role === "system" || messages[0].role === "developer") {
       messages[1].content = messages[0].content + messages[1].content;
       messages = messages.slice(1);
     }


### PR DESCRIPTION
feat: Add support for "developer" role in Messages type（for Cherry Studio call）

- Extended the `Messages` type to include the "developer" role, allowing it to be used alongside "user", "assistant", and "system".
- Updated the chat function to handle "developer" role similarly to "system", appending its content to the next message.

feat: 在 Messages 类型中添加对 "developer" 角色的支持（支持Cherry Studio调用）

- 扩展了 `Messages` 类型，允许使用 "developer" 角色，与 "user"、"assistant" 和 "system" 并列。
- 更新了 chat 函数，使其对 "developer" 角色与 "system" 角色采用相似的处理方式，将其内容附加到下一个消息中。